### PR TITLE
New condition callback: "valuesChanged"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ The built-in callback methods for determining whether or not to save.
   Only save if at least one input value has changed since the last autosave.
 * **interval**  
   Only save on intervals. If anything else triggers an autosave, it will wait until the next interval to save.
-* **valuesChanged**
+* **valuesChanged**  
   Just like 'changed', but doesn't wait for `onChange` events, so it will return true if a textbox has been edited but has not yet lost focus.
 
 #### Arguments

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,8 @@ The built-in callback methods for determining whether or not to save.
   Only save if at least one input value has changed since the last autosave.
 * **interval**  
   Only save on intervals. If anything else triggers an autosave, it will wait until the next interval to save.
+* **valuesChanged**
+* Just like 'changed', but doesn't wait for `onChange` events, so it will return true if a textbox has been edited but has not yet lost focus.
 
 #### Arguments
 

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ The built-in callback methods for determining whether or not to save.
 * **interval**  
   Only save on intervals. If anything else triggers an autosave, it will wait until the next interval to save.
 * **valuesChanged**
-* Just like 'changed', but doesn't wait for `onChange` events, so it will return true if a textbox has been edited but has not yet lost focus.
+  Just like 'changed', but doesn't wait for `onChange` events, so it will return true if a textbox has been edited but has not yet lost focus.
 
 #### Arguments
 

--- a/src/jquery.autosave.js
+++ b/src/jquery.autosave.js
@@ -565,6 +565,24 @@
       method: function() {
         return this.changedInputs().length > 0;
       }
+    },
+    /**
+     * This condition returns true if any of the values of the fields have changed.
+     * This differs from the 'changed' condition callback which waits for field
+     * onChange events and those don't get fired until the current input loses
+     * focus. Using this condition callback allows you to use an interval-based
+     * trigger to autosave while a user is still typing in a textbox, without
+     * calling unnecessary save() events if the values haven't changed.
+     */ 
+    valuesChanged: {
+      method: function() {
+        var curSerialized = this.forms().serialize();
+        if (!this.lastSerialized || curSerialized !== this.lastSerialized) {
+          this.lastSerialized = curSerialized;
+          return true;
+        }
+        return false;
+      }
     }
   });
 


### PR DESCRIPTION
Adding new callbacks.condition.valuesChanged which is a more aggressive form of condition.changed that takes into account changes to currently-being-edited textboxes.

This condition returns true if any of the values of the fields have changed. This differs from the 'changed' condition callback which waits for field  onChange events and those don't get fired until the current input loses
 focus. Using this condition callback allows you to use an interval-based trigger to autosave while a user is still typing in a textbox, without calling unnecessary save() events if the values haven't changed.
