### PR TITLE
Slight problem with interval callback posting multiple saves on dynamic pages.

### DIFF
--- a/src/jquery.autosave.js
+++ b/src/jquery.autosave.js
@@ -347,6 +347,9 @@
         if (!isNaN(parseInt(interval))) {
           this.timer = setTimeout(function() {
             self.save(false, self.timer);
+            if($(self.selector).length ===0) {
+               self.stopInterval();
+            }
           }, interval);
         }
     },


### PR DESCRIPTION
Set up interval callback so that on dynamic pages where the form gets removed and replaced (with a different form), the autosave interval is cancelled. It is based on the selector used to set up the autosave. Essentially if the selector doesn't return any elements, we cancel the interval.  If the newly generated form has the same id, you will still get multiple autosaves to show up.
