### PR TITLE
Feature inputevent

### DIFF
--- a/src/jquery.autosave.js
+++ b/src/jquery.autosave.js
@@ -206,7 +206,17 @@
         });
 
         // Listen for modifications on all inputs
-        $inputs.bind(["keyup", this.options.namespace].join("."), function(e) {
+        // first, figure out if html5 "input" event is available
+        // if not, use "keyup"
+        var el = document.createElement("input");
+        var inputSupported = ("oninput" in el);
+        if (!inputSupported) {  // work around for older versions of Firefox
+            el.setAttribute("oninput", "return;");
+            inputSupported = typeof el["oninput"] === "function";
+        }
+        el = null;
+        var modifyTriggerEvent = inputSupported ? "input" : "keyup";
+        $inputs.bind([modifyTriggerEvent, this.options.namespace].join("."), function(e) {
             $(this).addClass(self.options.classes.modified);
             $(this.form).triggerHandler(self.options.events.modified, [this]);
         });

--- a/tests/unit/callbacks.js
+++ b/tests/unit/callbacks.js
@@ -31,7 +31,7 @@ test("Trigger/Modified", function() {
     }
   });
 
-  $form.find(":input[type=text]").val("t").keyup();
+  $form.find(":input[type=text]").val("t").keyup().trigger("input");
 });
 
 asyncTest("Trigger/Interval", function() {
@@ -112,7 +112,7 @@ test("Scope/Modified", function() {
     }
   });
 
-  $form.find(":input[type=text]").val("t").keyup();
+  $form.find(":input[type=text]").val("t").keyup().trigger('input');
 });
 
 /**
@@ -212,7 +212,7 @@ test("Condition/Modified", function() {
   });
 
   $form.find(":input[name=save]").click();
-  $form.find(":input[type=text]").val("t").keyup();
+  $form.find(":input[type=text]").val("t").keyup().trigger('input');
 });
 
 /**


### PR DESCRIPTION
If the <code>input</code> event is supported by the browser, it is used instead of <code>keyup</code>. This way, input fields are marked as modified only when their values change.

Tested on Chrome, Firefox, IE8. Resolves issue #18.
