### PR TITLE
Only listen to elements passed to initialize

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -417,10 +417,7 @@ This event is fired on the form containing the input.
 
 jQuery.autosave requires:
 
-* jQuery version 1.4.0+ (recommended)
-* jQuery version 1.2.3+ (see note below)
-
-**Note**: There are several bugs in the [jQuery.extend](http://api.jquery.com/jQuery.extend/) function that will cause unexpected behavior in jQuery versions 1.3.2 and below. To make autosave fully compatible with jQuery versions 1.2.3 through 1.3.2, you should include the [jquery.extend-patch.js](https://github.com/kflorence/misc-js/blob/master/jquery/patches/jquery.extend-patch.js) file _before_ initializing the plugin. This file will add additional functionality to jQuery core and fix the extend method for you. Please be advised that this patch should only be used as a last resort. **If at all possible, please upgrade to jQuery version 1.4 or higher.**
+* jQuery version 1.4.0+
 
 ## Compatibility
 
@@ -432,7 +429,7 @@ Verified to work correctly on:
 
 ## Credits
 
-Written by [Kyle Florence](https://github.com/kflorence/).  
+Written by [Kyle Florence](https://github.com/kflorence/) and [other contributers](https://github.com/nervetattoo/jquery-autosave/graphs/contributors).
 Inspired by the jQuery.autosave plugin written by [Raymond Julin](https://github.com/nervetattoo/), Mads Erik Forberg and Simen Graaten.
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Options is a set of key/value pairs that can be passed into the plugin as the fi
 If you use this plugin as is (without providing any options), this is what you can expect.
 
 1. **trigger** An autosave is triggered any time an input value changes.
-2. **scope** The scope of inputs is narrowed to include only those whose value has changed since the last autosave.
+2. **scope** Due to the `change` default trigger, the scope of inputs is narrowed to include only those whose value has changed since the last autosave.
 3. **data** Data is gathered using jQuery's [.serialize()](http://api.jquery.com/serialize/) function.
 4. **condition** There are no conditions that need to pass to complete this save.
 5. **save** The data is sent to the current browser URL using the [jQuery.ajax()](http://api.jquery.com/jQuery.ajax/) function.

--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,6 @@ This plugin works strictly with forms and form inputs of any type. Any other ele
         saved: "saved",
         changed: "changed",
         modified: "modified"
-      },
-      classes: {
-        ignore: "ignore"
       }
     }
 
@@ -61,11 +58,7 @@ Options is a set of key/value pairs that can be passed into the plugin as the fi
   * **changed** _String_  
     This event is triggered whenever an input value changes ("change" event is fired) on the form containing that input. It can be bound to if you need to be notified whenever an input value changes.
   * **modified** _String_  
-    This event is triggered whenever an input value is modified ("keyup" event is fired) on the form containing that input. It can be bound to if you need to be notified whenever an input value is modified.
-* **classes** _Object_  
-  Contains a set of key/value pairs that allow yout o chang the name of classes used within the plugin. Keep in mind that these classes will be namespaced on initialization like: "namespace-className"
-  * **ignore** _String_  
-    Inputs with this class name will be ignored by the plugin when gathering data.
+    This event is triggered whenever an input value is modified ("input" or "keyup" event is fired) on the form containing that input. It can be bound to if you need to be notified whenever an input value is modified.
 
 ## Default Behavior
 
@@ -187,7 +180,7 @@ Trigger methods do not require a return value.
 The built-in callback methods for narrowing the scope of inputs we will gather data from.
 
 * **all**  
-  Uses all valid form inputs (those that aren't ignored).
+  Uses all valid form inputs
 * **changed**  
   Filters inputs down to only those that have had their value changed since the last autosave.
 * **modified**  

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,6 @@ This plugin works strictly with forms and form inputs of any type. Any other ele
         modified: "modified"
       },
       classes: {
-        changed: "changed",
-        modified: "modified",
         ignore: "ignore"
       }
     }
@@ -66,10 +64,6 @@ Options is a set of key/value pairs that can be passed into the plugin as the fi
     This event is triggered whenever an input value is modified ("keyup" event is fired) on the form containing that input. It can be bound to if you need to be notified whenever an input value is modified.
 * **classes** _Object_  
   Contains a set of key/value pairs that allow yout o chang the name of classes used within the plugin. Keep in mind that these classes will be namespaced on initialization like: "namespace-className"
-  * **changed** _String_  
-    The class name that will be applied to elements whose value has been changed but not yet saved.
-  * **changed** _String_  
-    The class name that will be applied to elements whose value has been modified but not yet saved.
   * **ignore** _String_  
     Inputs with this class name will be ignored by the plugin when gathering data.
 

--- a/src/jquery.autosave.js
+++ b/src/jquery.autosave.js
@@ -66,7 +66,14 @@
 
   $.autosave = {
     timer: 0,
+
     $queues: $({}),
+
+    states: {
+        changed: "changed",
+        modified: "modified"
+    },
+
     options: {
       namespace: "autosave",
       callbacks: {
@@ -83,8 +90,6 @@
         modified: "modified"
       },
       classes: {
-        changed: "changed",
-        modified: "modified",
         ignore: "ignore"
       }
     },
@@ -150,7 +155,7 @@
 
         // Listen for changes on all inputs
         $inputs.bind(["change", this.options.namespace].join("."), function(e) {
-          $(this).addClass(self.options.classes.changed);
+          $(this).data([self.options.namespace, self.states.changed].join("."), true);
           $(this.form).triggerHandler(self.options.events.changed, [this]);
         });
 
@@ -158,7 +163,7 @@
         // Use html5 "input" event is available. Otherwise, use "keyup".
         var modifyTriggerEvent = inputSupported ? "input" : "keyup";
         $inputs.bind([modifyTriggerEvent, this.options.namespace].join("."), function(e) {
-          $(this).addClass(self.options.classes.modified);
+          $(this).data([self.options.namespace, self.states.modified].join("."), true);
           $(this.form).triggerHandler(self.options.events.modified, [this]);
         });
 
@@ -257,7 +262,7 @@
       var self = this;
 
       return this.inputs(inputs).filter(function() {
-        return $(this).hasClass(self.options.classes.changed);
+        return $(this).data([self.options.namespace, self.states.changed].join("."));
       });
     },
 
@@ -275,7 +280,7 @@
       var self = this;
 
       return this.inputs(inputs).filter(function() {
-        return $(this).hasClass(self.options.classes.modified);
+        return $(this).data([self.options.namespace, self.states.modified].join("."));
       });
     },
 
@@ -404,8 +409,8 @@
      * Reset which elements where changed/modified before saving.
      */
     resetFields: function() {
-      this.changedInputs().removeClass(this.options.classes.changed);
-      this.modifiedInputs().removeClass(this.options.classes.modified);
+      this.inputs().data([this.options.namespace, this.states.changed].join("."), false);
+      this.inputs().data([this.options.namespace, this.states.modified].join("."), false);
     },
 
     /**

--- a/src/jquery.autosave.js
+++ b/src/jquery.autosave.js
@@ -109,11 +109,8 @@
     initialize: function($elements, options) {
       var self = this;
 
-      $.extend(this, {
-        context: $elements.context || document,
-        selector: $elements.selector || $elements,
-        options: $.extend(true, {}, this.options, options)
-      });
+      this.$elements = $elements;
+      this.options = $.extend(true, {}, this.options, options);
 
       // If length == 0, we have no forms or inputs
       if (this.elements().length) {
@@ -177,23 +174,18 @@
     },
 
     /**
-     * Returns the forms and inputs matched by the selector and context.
+     * Returns the forms and inputs within a specific context.
      *
-     * @param {jQuery|Element|Element[]} [selector]
-     *    The selector expression to use. Uses the selector passed into the
-     *    plugin by default.
-     *
-     * @param {jQuery|Element|Document} [context]
-     *    A context to limit our search. Uses document by default.
+     * @param {jQuery|Element|Element[]} [elements]
+     *    The elements to search within. Uses the pass elements by default.
      *
      * @return {jQuery}
      *    A jQuery object containing any matched form and input elements.
      */
-    elements: function(selector, context) {
-      selector = selector || this.selector;
-      context = context || this.context;
+    elements: function(elements) {
+      if (!elements) elements = this.$elements;
 
-      return $(selector, context).filter(function() {
+      return $(elements).filter(function() {
         return (this.elements || this.form);
       });
     },

--- a/src/jquery.autosave.js
+++ b/src/jquery.autosave.js
@@ -88,9 +88,6 @@
         saved: "saved",
         changed: "changed",
         modified: "modified"
-      },
-      classes: {
-        ignore: "ignore"
       }
     },
 
@@ -121,10 +118,6 @@
 
         $.each(this.options.events, function(name, eventName) {
           self.options.events[name] = [eventName, self.options.namespace].join(".");
-        });
-
-        $.each(this.options.classes, function(name, className) {
-          self.options.classes[name] = [self.options.namespace, className].join("-");
         });
 
         // Parse callback options into an array of callback objects
@@ -233,11 +226,7 @@
      *    A jQuery object containing any matched input elements.
      */
     validInputs: function(inputs) {
-      var self = this;
-
-      return this.inputs(inputs).filter(function() {
-        return !$(this).hasClass(self.options.classes.ignore);
-      });
+      return this.inputs(inputs);
     },
 
     /**


### PR DESCRIPTION
only add listeners to the elements passed to the jquery plugin

also getting rid of all classes, to avoid DOM calls for performance (especially during `interval` timer)
- using $.data instead of changed/modified
- removing `ignored` class check b/c similar behavior can be replicated via `scope` or `condition`

Fixes #30
